### PR TITLE
feat: Implement POST /api/tasks endpoint

### DIFF
--- a/app/api/tasks/route.ts
+++ b/app/api/tasks/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import prisma from '@/lib/prisma';
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { title } = body;
+
+    if (!title || typeof title !== 'string' || title.trim() === '') {
+      return NextResponse.json(
+        { error: 'Title is required and must be a non-empty string' },
+        { status: 400 }
+      );
+    }
+
+    const task = await prisma.task.create({
+      data: {
+        title: title.trim(),
+        completed: false,
+      },
+    });
+
+    return NextResponse.json(task, { status: 201 });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
Fixes #8

This PR adds the `/api/tasks` POST endpoint to allow users to create new tasks.

### Changes:
- Created `app/api/tasks/route.ts` to handle incoming POST requests.
- The endpoint expects a JSON body with a `title` field.

### Validation & Error Handling:
- **Validation:** The endpoint checks if `title` exists, is a string, and is not just whitespace. If validation fails, a `400 Bad Request` status is returned with a descriptive error message.
- **Error Handling:** A `try-catch` block is used to wrap the database operation. If the database call fails, it returns a `500 Internal Server Error`.

---
*This PR was autonomously generated by [Pangea 3](https://github.com/sebmuehlbauer) — an AI-powered development system.*